### PR TITLE
Include date in CurrencyExchangeRateStore

### DIFF
--- a/src/v1/schemas/models/CurrencyExchangeRate/CurrencyExchangeRateStore.yaml
+++ b/src/v1/schemas/models/CurrencyExchangeRate/CurrencyExchangeRateStore.yaml
@@ -1,10 +1,17 @@
 CurrencyExchangeRateStore:
   type: object
   required:
+    - date
     - from
     - to
     - rates
   properties:
+    date:
+      type: string
+      format: date
+      example: "%start_date%"
+      description: "The date to which the exchange rate is applicable."
+      nullable: false
     from:
       type: string
       format: string


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->

Calling `POST /api/v1/exchange-rates`, I was hit with `The date field is required.`.