### PR TITLE
Fix typo in RuleTriggerKeyword.yaml

### DIFF
--- a/src/v1/schemas/properties/RuleTriggerKeyword.yaml
+++ b/src/v1/schemas/properties/RuleTriggerKeyword.yaml
@@ -32,7 +32,7 @@ RuleTriggerKeyword:
     - has_no_tag
     - has_any_tag
     - notes_contains
-    - notes_start
+    - notes_starts
     - notes_end
     - notes_are
     - no_notes


### PR DESCRIPTION
Changes in this pull request:

- in RuleTriggerKeyword I changed "notes_start" to "notes_starts"
