### PR TITLE
Add 'daily' option to InterestPeriodProperty enum

### DIFF
--- a/src/shared/properties/InterestPeriodProperty.yaml
+++ b/src/shared/properties/InterestPeriodProperty.yaml
@@ -5,6 +5,7 @@ InterestPeriodProperty:
   description: "Mandatory when type is liability. Period over which the interest is calculated."
   nullable: true
   enum:
+    - daily
     - weekly
     - monthly
     - quarterly


### PR DESCRIPTION
As discussed in https://github.com/orgs/firefly-iii/discussions/11514,
This PR adds the missing value 'daily' to the InterestPeriodProperty enum