### PR TITLE
Document the /subscriptions endpoints (alias of /bills)

### DIFF
--- a/src/v1/paths/data/export.yaml
+++ b/src/v1/paths/data/export.yaml
@@ -55,6 +55,34 @@
             schema:
               type: string
               format: binary
+/data/export/subscriptions:
+  get:
+    summary: Export subscriptions from Firefly III
+    description: |
+      This endpoint allows you to export your subscriptions (also known as bills) from Firefly III into a file. Currently supports CSV exports only.
+    operationId: exportSubscriptions
+    tags:
+      - data
+    parameters:
+      _tpl_correlationParameter,3:
+      - in: query
+        name: type
+        description: The file type the export file (CSV is currently the only option).
+        required: false
+        schema:
+          $ref: '#/components/schemas/ExportFileFilter'
+    responses:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:
+      "200":
+        description: 'The exported transaction in a file.'
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
 /data/export/budgets:
   get:
     summary: Export budgets and budget amount data from Firefly III

--- a/src/v1/paths/models/subscription-list.yaml
+++ b/src/v1/paths/models/subscription-list.yaml
@@ -1,0 +1,109 @@
+/subscriptions/{id}/attachments:
+  get:
+    summary: List all attachments uploaded to the subscription.
+    description: This endpoint will list all attachments linked to the subscription (also known as a bill).
+    operationId: listAttachmentBySubscription
+    tags:
+      - bills
+    parameters:
+      _tpl_correlationParameter,3:
+      _tpl_limitParameter,3:
+      _tpl_pageParameter,3:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: "123"
+        description: The ID of the subscription.
+    responses:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:
+      "200":
+        description: A list of attachments
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/AttachmentArray'
+/subscriptions/{id}/rules:
+  get:
+    summary: List all rules associated with the subscription.
+    description: This endpoint will list all rules that have an action to set the subscription (bill) to this subscription.
+    operationId: listRuleBySubscription
+    tags:
+      - bills
+    parameters:
+      _tpl_correlationParameter,3:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: "123"
+        description: The ID of the subscription.
+    responses:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:
+      "200":
+        description: A list of rules
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/RuleArray'
+/subscriptions/{id}/transactions:
+  get:
+    summary: List all transactions associated with the subscription.
+    description: This endpoint will list all transactions linked to this subscription (also known as a bill).
+    operationId: listTransactionBySubscription
+    tags:
+      - bills
+    parameters:
+      _tpl_correlationParameter,3:
+      _tpl_limitParameter,3:
+      _tpl_pageParameter,3:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: "123"
+        description: The ID of the subscription.
+      - in: query
+        name: start
+        description: |
+          A date formatted YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
+          example: "%start_date%"
+      - in: query
+        name: end
+        description: |
+          A date formatted YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
+          example: "%end_date%"
+      - in: query
+        name: type
+        description: Optional filter on the transaction type(s) returned
+        required: false
+        schema:
+          $ref: '#/components/schemas/TransactionTypeFilter'
+    responses:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:
+      "200":
+        description: A list of transactions
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/TransactionArray'

--- a/src/v1/paths/models/subscription.yaml
+++ b/src/v1/paths/models/subscription.yaml
@@ -1,0 +1,174 @@
+/subscriptions:
+  get:
+    summary: List all subscriptions.
+    description: This endpoint will list all the user's subscriptions. Subscriptions are also known as bills, and this endpoint is an alias of `/bills`.
+    operationId: listSubscription
+    tags:
+      - bills
+    parameters:
+      _tpl_correlationParameter,3:
+      _tpl_limitParameter,3:
+      _tpl_pageParameter,3:
+      - in: query
+        name: start
+        description: |
+          A date formatted YYYY-MM-DD. If it is are added to the request, Firefly III will calculate the appropriate payment and paid dates.
+        required: false
+        schema:
+          type: string
+          format: date
+          example: "%start_date%"
+      - in: query
+        name: end
+        description: |
+          A date formatted YYYY-MM-DD. If it is added to the request, Firefly III will calculate the appropriate payment and paid dates.
+        required: false
+        schema:
+          type: string
+          format: date
+          example: "%start_date%"
+    responses:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:
+      "200":
+        description: A list of subscriptions
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/BillArray'
+  post:
+    summary: Store a new subscription
+    description: Creates a new subscription. The data required can be submitted as a JSON body or as a list of parameters. Subscriptions are also known as bills.
+    operationId: storeSubscription
+    parameters:
+      _tpl_correlationParameter,3:
+    tags:
+      - bills
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BillStore'
+        application/x-www-form-urlencoded:
+          schema:
+            $ref: '#/components/schemas/BillStore'
+      description: "JSON array or key=value pairs with the necessary subscription information. See the model for the exact specifications."
+      required: true
+    responses:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:
+      "200":
+        description: 'New subscription stored, result in response.'
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/BillSingle'
+      _tpl_validationErrorResponse,3:
+/subscriptions/{id}:
+  get:
+    summary: Get a single subscription.
+    description: Get a single subscription. Subscriptions are also known as bills.
+    operationId: getSubscription
+    parameters:
+      _tpl_correlationParameter,3:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: "123"
+        description: The ID of the subscription.
+      - in: query
+        name: start
+        description: |
+          A date formatted YYYY-MM-DD. If it is are added to the request, Firefly III will calculate the appropriate payment and paid dates.
+        required: false
+        schema:
+          type: string
+          format: date
+          example: "%start_date%"
+      - in: query
+        name: end
+        description: |
+          A date formatted YYYY-MM-DD. If it is added to the request, Firefly III will calculate the appropriate payment and paid dates.
+        required: false
+        schema:
+          type: string
+          format: date
+          example: "%end_date%"
+    tags:
+      - bills
+    responses:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:
+      "200":
+        description: 'The requested subscription'
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/BillSingle'
+  put:
+    operationId: updateSubscription
+    tags:
+      - bills
+    description: Update existing subscription.
+    summary: Update existing subscription.
+    parameters:
+      _tpl_correlationParameter,3:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: "123"
+        description: The ID of the subscription.
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BillUpdate'
+        application/x-www-form-urlencoded:
+          schema:
+            $ref: '#/components/schemas/BillUpdate'
+      description: JSON array or key=value pairs with updated subscription information. See the model for the exact specifications.
+      required: true
+    responses:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:
+      "200":
+        description: 'Updated subscription stored, result in response'
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/BillSingle'
+      _tpl_validationErrorResponse,3:
+  delete:
+    operationId: deleteSubscription
+    description: Delete a subscription. This will not delete any associated rules. Will not remove associated transactions. WILL remove all associated attachments.
+    summary: Delete a subscription.
+    tags:
+      - bills
+    parameters:
+      _tpl_correlationParameter,3:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: "123"
+        description: The ID of the subscription.
+    responses:
+      "204":
+        description: Subscription deleted.
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:


### PR DESCRIPTION
As discussed in [#12380](https://github.com/orgs/firefly-iii/discussions/12380), several `v1` routes exist in `routes/api.php` but are missing from the OpenAPI spec. This PR documents the first, self-contained group: the `/subscriptions` resource.

`/v1/subscriptions` is served by the same `Models\Bill` controllers as `/v1/bills` (verified in `routes/api.php` on `develop`), so the partials mirror the existing `bills` source files, reusing their schemas (`BillArray`, `BillStore`, `BillSingle`, `BillUpdate`) and the `bills` tag.

### Changes
- **`src/v1/paths/models/subscription.yaml`** (new) — `GET,POST /subscriptions` and `GET,PUT,DELETE /subscriptions/{id}`
- **`src/v1/paths/models/subscription-list.yaml`** (new) — `/subscriptions/{id}/attachments`, `/rules`, `/transactions`
- **`src/v1/paths/data/export.yaml`** — adds `GET /data/export/subscriptions`

### Notes
- All new `operationId`s are unique across `src/` (`listSubscription`, `storeSubscription`, `getSubscription`, `updateSubscription`, `deleteSubscription`, `listAttachmentBySubscription`, `listRuleBySubscription`, `listTransactionBySubscription`, `exportSubscriptions`).
- Tag kept as `bills` since subscriptions are the same resource; happy to switch to a dedicated `subscriptions` tag if you prefer.
- I could not run `api-docs-generator` locally (no PHP), so I relied on YAML validation and mirroring the working `bills` partials. Please let me know if the stitched output looks off.
- More undocumented endpoints remain (user-groups membership, currencies/default, currency rates, etc.); I will send those in follow-up PRs.