### PR TITLE
Document the remaining undocumented v1 read endpoints

### DIFF
--- a/src/v1/paths/models/piggy-bank-list.yaml
+++ b/src/v1/paths/models/piggy-bank-list.yaml
@@ -58,3 +58,32 @@
       _tpl_notFoundResponse,3:
       _tpl_badRequestResponse,3:
       _tpl_internalExceptionResponse,3:
+/piggy-banks/{id}/accounts:
+  get:
+    summary: List all accounts linked to a piggy bank.
+    description: List all accounts linked to a piggy bank. A piggy bank can be linked to multiple accounts.
+    operationId: listAccountByPiggyBank
+    tags:
+      - piggy_banks
+    parameters:
+      _tpl_correlationParameter,3:
+      _tpl_limitParameter,3:
+      _tpl_pageParameter,3:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: "123"
+        description: The ID of the piggy bank.
+    responses:
+      "200":
+        description: A list of accounts
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/AccountArray'
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:

--- a/src/v1/paths/models/rule.yaml
+++ b/src/v1/paths/models/rule.yaml
@@ -136,3 +136,37 @@
       _tpl_notFoundResponse,3:
       _tpl_badRequestResponse,3:
       _tpl_internalExceptionResponse,3:
+/rules/validate-expression:
+  get:
+    summary: Validate an action expression.
+    description: |
+      Validate an action expression as used in rule actions. Returns whether the submitted expression is valid.
+      If the expression is invalid, a 422 validation error is returned instead.
+    operationId: validateActionExpression
+    tags:
+      - rules
+    parameters:
+      _tpl_correlationParameter,3:
+      - in: query
+        name: expression
+        description: The action expression to validate.
+        required: true
+        schema:
+          type: string
+          example: "{{ description | upper }}"
+    responses:
+      "200":
+        description: The expression is valid.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                valid:
+                  type: boolean
+                  example: true
+      _tpl_validationErrorResponse,3:
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:

--- a/src/v1/paths/models/transaction-currency-list.yaml
+++ b/src/v1/paths/models/transaction-currency-list.yaml
@@ -264,3 +264,33 @@
       _tpl_notFoundResponse,3:
       _tpl_badRequestResponse,3:
       _tpl_internalExceptionResponse,3:
+/currencies/{code}/cer:
+  get:
+    summary: List all exchange rates for this currency.
+    description: List all currency exchange rates that have this currency as the source or destination currency.
+    operationId: listExchangeRatesByCurrency
+    tags:
+      - currencies
+    parameters:
+      _tpl_correlationParameter,3:
+      _tpl_limitParameter,3:
+      _tpl_pageParameter,3:
+      - in: path
+        name: code
+        required: true
+        schema:
+          type: string
+          format: string
+          example: USD
+        description: The currency code.
+    responses:
+      "200":
+        description: A list of currency exchange rates.
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/CurrencyExchangeRateArray'
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:

--- a/src/v1/paths/models/transaction-currency.yaml
+++ b/src/v1/paths/models/transaction-currency.yaml
@@ -248,3 +248,23 @@
       _tpl_notFoundResponse,3:
       _tpl_badRequestResponse,3:
       _tpl_internalExceptionResponse,3:
+/currencies/default:
+  get:
+    summary: Get the default (primary) currency of the current administration.
+    description: Get the default currency of the current administration. This is an alias of `/currencies/primary`.
+    operationId: getDefaultCurrency
+    parameters:
+      _tpl_correlationParameter,3:
+    tags:
+      - currencies
+    responses:
+      "200":
+        description: 'The default currency'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CurrencySingle'
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:

--- a/src/v1/paths/search/search.yaml
+++ b/src/v1/paths/search/search.yaml
@@ -72,3 +72,64 @@
       _tpl_notFoundResponse,3:
       _tpl_badRequestResponse,3:
       _tpl_internalExceptionResponse,3:
+/search/transactions/count:
+  get:
+    summary: Count transactions matching the given filters.
+    description: |
+      Returns the number of transactions that match the given meta-field filters. This is useful to check for
+      existing transactions (for example to avoid duplicates) before storing new data.
+    operationId: countTransactions
+    tags:
+      - search
+    parameters:
+      _tpl_correlationParameter,3:
+      - in: query
+        name: external_identifier
+        description: Count transactions with this exact external identifier.
+        required: false
+        schema:
+          type: string
+          example: "abcd-1234"
+      - in: query
+        name: internal_reference
+        description: Count transactions with this exact internal reference.
+        required: false
+        schema:
+          type: string
+          example: "INV-998"
+      - in: query
+        name: notes
+        description: Count transactions whose notes contain this string.
+        required: false
+        schema:
+          type: string
+          example: "groceries"
+      - in: query
+        name: description
+        description: Count transactions with this exact description.
+        required: false
+        schema:
+          type: string
+          example: "Monthly rent"
+      - in: query
+        name: include_deleted
+        description: Whether to include soft-deleted transactions in the count.
+        required: false
+        schema:
+          type: boolean
+          example: false
+    responses:
+      "200":
+        description: The number of matching transactions.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                count:
+                  type: integer
+                  example: 42
+      _tpl_unauthenticatedResponse,3:
+      _tpl_notFoundResponse,3:
+      _tpl_badRequestResponse,3:
+      _tpl_internalExceptionResponse,3:


### PR DESCRIPTION
Follow-up to #16 and [discussion #12380](https://github.com/orgs/firefly-iii/discussions/12380). This documents the remaining `v1` GET endpoints that exist in `routes/api.php` but were missing from the spec.

I did a method-level diff of `routes/api.php` (on `develop`) against `dist/firefly-iii-develop-v1.yaml`. After excluding routes that are commented out in the source (e.g. the `user-groups` and `available-budgets` write endpoints), these five GET endpoints were the only ones left undocumented:

### Endpoints
| Endpoint | File | Response |
|---|---|---|
| `GET /currencies/default` | `models/transaction-currency.yaml` | `CurrencySingle` (alias of `/currencies/primary`) |
| `GET /currencies/{code}/cer` | `models/transaction-currency-list.yaml` | `CurrencyExchangeRateArray` |
| `GET /piggy-banks/{id}/accounts` | `models/piggy-bank-list.yaml` | `AccountArray` |
| `GET /rules/validate-expression` | `models/rule.yaml` | inline `{ valid: boolean }` (+ 422 on invalid) |
| `GET /search/transactions/count` | `search/search.yaml` | inline `{ count: integer }` |

### Notes
- Response shapes were verified against the controllers on `develop` (`ShowController@showPrimary`, `ListController@cer`, `ListController@accounts`, `ExpressionController@validateExpression`, `Search\TransactionController@count`).
- The two non-standard responses use inline object schemas since they do not map to an existing component schema.
- All five `operationId`s are unique across `src/`.
- This time I ran `api-docs-generator` locally (PHP 8.4): the stitched output builds cleanly and includes all five paths.

This should close the gap from the discussion. A small correction to my earlier comment there: the `user-groups` membership endpoints I mentioned are actually commented out in `routes/api.php`, so they are not active and are intentionally not included here.